### PR TITLE
Add NPM Scripts for Services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "wistful-bison",
+  "version": "1.0.0",
+  "description": "Application Layer for Athena",
+  "main": "./server/index.js",
+  "scripts": {
+    "start": "nodemon ../app/server/index.js $PORT & nodemon ../user/server/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "author": "",
+  "license": "",
+  "bugs": {
+    "url": ""
+  },
+  "dependencies": {
+    "body-parser": "^1.15.2",
+    "chalk": "^1.1.3",
+    "express": "^4.14.0",
+    "express-session": "^1.14.1",
+    "morgan": "^1.7.0",
+    "nodemon": "^1.10.2",
+    "request": "^2.74.0"
+  }
+}


### PR DESCRIPTION
Running npm start will kick off other services if all services are stored in the same top folder.
